### PR TITLE
feat: run integration tests against Docker containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,17 +6,6 @@ on:
       ref:
         required: true
         type: string
-    secrets:
-      BASE_URL:
-        required: false
-      AUTH_TOKEN:
-        required: false
-      JWT_KEY:
-        required: false
-      CLIENT_ID:
-        required: false
-      CLIENT_SECRET:
-        required: false
 
 defaults:
   run:
@@ -49,12 +38,6 @@ jobs:
 
       - name: Run Tests
         run: npm run test
-        env:
-          BASE_URL: ${{ secrets.BASE_URL }}
-          AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
-          JWT_KEY: ${{ secrets.JWT_KEY }}
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
       - name: Upload Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/etc/docker-compose.yaml
+++ b/etc/docker-compose.yaml
@@ -1,0 +1,98 @@
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: postgres
+    networks:
+      - storage
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready', '-d', 'db_prod']
+      interval: 10s
+      timeout: 60s
+      retries: 5
+      start_period: 10s
+    volumes:
+      - data:/var/lib/postgresql/data:rw
+
+  zitadel-init:
+    restart: 'no'
+    networks:
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest'
+    command: 'init --config /example-zitadel-config.yaml --config /example-zitadel-secrets.yaml'
+    depends_on:
+      db:
+        condition: 'service_healthy'
+    volumes:
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './zitadel_output:/var/zitadel_output:rw'
+
+  zitadel-setup:
+    restart: 'no'
+    networks:
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest-debug'
+    user: root
+    entrypoint: '/bin/bash'
+    command:
+      [
+        '-c',
+        '/app/zitadel setup --config /example-zitadel-config.yaml --config /example-zitadel-secrets.yaml --steps /example-zitadel-init-steps.yaml --masterkey "my_test_masterkey_0123456789ABEF" && echo "--- ZITADEL SETUP COMPLETE ---" && echo "Personal Access Token (PAT) will be in ./zitadel_output/pat.txt on your host." && echo "Service Account Key will be in ./zitadel_output/sa-key.json on your host." && echo "OAuth Client ID and Secret will be in ''zitadel'' service logs (grep for ''Application created'')."',
+      ]
+    environment:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app
+    depends_on:
+      zitadel-init:
+        condition: 'service_completed_successfully'
+        restart: false
+    volumes:
+      - './zitadel_output:/var/zitadel_output:rw'
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './example-zitadel-init-steps.yaml:/example-zitadel-init-steps.yaml:ro'
+
+  zitadel:
+    restart: 'unless-stopped'
+    networks:
+      - backend
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest'
+    command: >
+      start --config /example-zitadel-config.yaml
+      --config /example-zitadel-secrets.yaml
+      --masterkey my_test_masterkey_0123456789ABEF
+    depends_on:
+      zitadel-setup:
+        condition: 'service_completed_successfully'
+        restart: true
+    volumes:
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './zitadel_output:/var/zitadel_output:rw'
+    ports:
+      - '8099:8080'
+    healthcheck:
+      test:
+        [
+          'CMD',
+          '/app/zitadel',
+          'ready',
+          '--config',
+          '/example-zitadel-config.yaml',
+          '--config',
+          '/example-zitadel-secrets.yaml',
+        ]
+      interval: 10s
+      timeout: 60s
+      retries: 5
+      start_period: 10s
+
+networks:
+  storage: {}
+  backend: {}
+
+volumes:
+  data: {}

--- a/etc/example-zitadel-config.yaml
+++ b/etc/example-zitadel-config.yaml
@@ -1,0 +1,17 @@
+ExternalSecure: false
+ExternalDomain: localhost
+ExternalPort: 8080
+TLS.Enabled: false
+Database:
+  postgres:
+    Host: 'db'
+    Port: 5432
+    Database: zitadel
+    User.SSL.Mode: 'disable'
+    Admin.SSL.Mode: 'disable'
+OIDC:
+  DefaultLoginURLV2: '/ui/v2/login/login?authRequest='
+  DefaultLogoutURLV2: '/ui/v2/login/logout?post_logout_redirect='
+SAML.DefaultLoginURLV2: '/ui/v2/login/login?authRequest='
+LogStore.Access.Stdout.Enabled: true
+DefaultInstance.LoginPolicy.MfaInitSkipLifetime: '0s'

--- a/etc/example-zitadel-init-steps.yaml
+++ b/etc/example-zitadel-init-steps.yaml
@@ -1,0 +1,35 @@
+FirstInstance:
+  MachineKeyPath: '/var/zitadel_output/sa-key.json'
+  PatPath: '/var/zitadel_output/pat.txt'
+  Org:
+    Human:
+      PasswordChangeRequired: false
+      Username: zitadel-admin@zitadel.localhost
+      Password: Password1!
+    Machine:
+      Machine:
+        Username: api-user
+        Name: Combined API User
+      MachineKey:
+        ExpirationDate: '2030-01-01T00:00:00Z'
+        Type: 1
+      Pat:
+        ExpirationDate: '2030-01-01T00:00:00Z'
+  Applications:
+    - OIDC:
+        RedirectUris:
+          - http://localhost:8080/callback
+          - http://127.0.0.1:8080/callback
+        ResponseTypes:
+          - CODE
+          - ID_TOKEN
+          - TOKEN
+        GrantTypes:
+          - AUTHORIZATION_CODE
+          - IMPLICIT
+          - REFRESH_TOKEN
+          - CLIENT_CREDENTIALS
+        AuthMethodType: POST
+      Name: 'MyOAuthAPIClient'
+      Type: 'WEB'
+DefaultInstance.LoginPolicy.MfaInitSkipLifetime: '0s'

--- a/etc/example-zitadel-secrets.yaml
+++ b/etc/example-zitadel-secrets.yaml
@@ -1,0 +1,8 @@
+Database:
+  postgres:
+    User:
+      Username: 'zitadel_user'
+      Password: 'zitadel'
+    Admin:
+      Username: 'root'
+      Password: 'postgres'

--- a/spec/auth/use-access-token.spec.ts
+++ b/spec/auth/use-access-token.spec.ts
@@ -1,11 +1,7 @@
 import Zitadel from '../../src/index.js';
 // noinspection ES6PreferShortImport
 import { ZitadelException } from '../../src/zitadel-exception.js';
-
-/**
- * Retrieve a configuration variable from the environment.
- */
-const env = (key: string): string => process.env[key] ?? '';
+import { useIntegrationEnvironment } from '../base-spec.js';
 
 /**
  * SettingsService Integration Tests (Personal Access Token)
@@ -17,6 +13,8 @@ const env = (key: string): string => process.env[key] ?? '';
  * 2. Expect an ApiException when using an invalid token
  */
 describe('UseAccessTokenSpec', () => {
+  const { context } = useIntegrationEnvironment();
+
   /**
    * Validate retrieval of general settings with a valid PAT.
    *
@@ -24,7 +22,7 @@ describe('UseAccessTokenSpec', () => {
    * @doesNotPerformAssertions
    */
   it('testRetrievesGeneralSettingsWithValidAuth', async () => {
-    const client = Zitadel.withAccessToken(env('BASE_URL'), env('AUTH_TOKEN'));
+    const client = Zitadel.withAccessToken(context.baseUrl, context.authToken);
 
     await client.settings.settingsServiceGetGeneralSettings();
   });
@@ -34,7 +32,7 @@ describe('UseAccessTokenSpec', () => {
    * @throws {Error}
    */
   it('testRaisesApiExceptionWithInvalidAuth', async () => {
-    const invalid = Zitadel.withAccessToken(env('BASE_URL'), 'invalid');
+    const invalid = Zitadel.withAccessToken(context.baseUrl, 'invalid');
 
     await expect(
       invalid.settings.settingsServiceGetGeneralSettings(),

--- a/spec/auth/use-client-credentials.spec.ts
+++ b/spec/auth/use-client-credentials.spec.ts
@@ -1,11 +1,7 @@
 import Zitadel from '../../src/index.js';
 // noinspection ES6PreferShortImport
 import { ZitadelException } from '../../src/zitadel-exception.js';
-
-/**
- * Retrieve a configuration variable from the environment.
- */
-const env = (key: string): string => process.env[key] ?? '';
+import { useIntegrationEnvironment } from '../base-spec.js';
 
 /**
  * SettingsService Integration Tests (Client Credentials)
@@ -17,6 +13,94 @@ const env = (key: string): string => process.env[key] ?? '';
  * 2. Expect an ApiException when using invalid credentials
  */
 describe('UseClientCredentialsSpec', () => {
+  const { context } = useIntegrationEnvironment();
+
+  async function generateUserSecret(token: string, loginName = 'api-user') {
+    const userUrl = new URL(
+      'http://localhost:8099/management/v1/global/users/_by_login_name',
+    );
+    userUrl.searchParams.set('loginName', loginName);
+
+    let userIdResponse;
+    try {
+      userIdResponse = await fetch(userUrl.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(
+          `API call to retrieve user failed for login name: '${loginName}'. Reason: ${error.message}`,
+        );
+      }
+      throw new Error(
+        `An unknown error occurred while retrieving user for login name: '${loginName}'.`,
+      );
+    }
+
+    if (userIdResponse.ok) {
+      const userPayload = await userIdResponse.json();
+      const userId = userPayload?.user?.id;
+
+      if (userId && typeof userId === 'string') {
+        const secretUrl = `http://localhost:8099/management/v1/users/${userId}/secret`;
+
+        let secretResponse;
+        try {
+          secretResponse = await fetch(secretUrl, {
+            method: 'PUT',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+            body: '{}',
+          });
+        } catch (error) {
+          if (error instanceof Error) {
+            throw new Error(
+              `API call to generate secret failed for user ID: '${userId}'. Reason: ${error.message}`,
+            );
+          }
+          throw new Error(
+            `An unknown error occurred during the API call to generate a secret for user ID: '${userId}'.`,
+          );
+        }
+
+        if (secretResponse.ok) {
+          const secretData = await secretResponse.json();
+          const { clientId, clientSecret } = secretData;
+
+          if (clientId && clientSecret) {
+            return { clientId, clientSecret };
+          } else {
+            console.log(secretData);
+            throw new Error(
+              "API response for secret is missing 'clientId' or 'clientSecret'.",
+            );
+          }
+        } else {
+          const errorBody = await secretResponse.text();
+          throw new Error(
+            `API call to generate secret failed for user ID: '${userId}'. Response: ${errorBody}`,
+          );
+        }
+      } else {
+        console.log(userPayload);
+        throw new Error(
+          `Could not parse a valid user ID from API response for login name: '${loginName}'.`,
+        );
+      }
+    } else {
+      const errorBody = await userIdResponse.text();
+      throw new Error(
+        `API call to retrieve user failed for login name: '${loginName}'. Response: ${errorBody}`,
+      );
+    }
+  }
+
   /**
    * Validate retrieval of general settings with valid client credentials.
    *
@@ -25,10 +109,11 @@ describe('UseClientCredentialsSpec', () => {
    * @doesNotPerformAssertions
    */
   it('testRetrievesGeneralSettingsWithValidAuth', async () => {
+    const credentials = await generateUserSecret(context.authToken);
     const client = await Zitadel.withClientCredentials(
-      env('BASE_URL'),
-      env('CLIENT_ID'),
-      env('CLIENT_SECRET'),
+      context.baseUrl,
+      credentials.clientId,
+      credentials.clientSecret,
     );
 
     await client.settings.settingsServiceGetGeneralSettings();
@@ -40,7 +125,7 @@ describe('UseClientCredentialsSpec', () => {
    */
   it('testRaisesApiExceptionWithInvalidAuth', async () => {
     const invalid = await Zitadel.withClientCredentials(
-      env('BASE_URL'),
+      context.baseUrl,
       'invalid',
       'invalid',
     );

--- a/spec/auth/use-private-key.spec.ts
+++ b/spec/auth/use-private-key.spec.ts
@@ -1,23 +1,7 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import Zitadel from '../../src/index.js';
 // noinspection ES6PreferShortImport
 import { ZitadelException } from '../../src/zitadel-exception.js';
-
-/**
- * Retrieve a configuration variable from the environment.
- */
-const env = (key: string): string => process.env[key] ?? '';
-
-const createTempJwtFile = (): string => {
-  const k = env('JWT_KEY');
-  // Note: Using a simple temp file name for clarity.
-  // In a real-world concurrent test suite, a more robust unique name is advised.
-  const p = path.join(os.tmpdir(), `jwt_${Date.now()}`);
-  fs.writeFileSync(p, k);
-  return p;
-};
+import { useIntegrationEnvironment } from '../base-spec.js';
 
 /**
  * SettingsService Integration Tests (Private Key Assertion)
@@ -29,6 +13,8 @@ const createTempJwtFile = (): string => {
  * 2. Expect an ApiException when using an invalid private key
  */
 describe('UsePrivateKeySpec', () => {
+  const { context } = useIntegrationEnvironment();
+
   /**
    * Validate retrieval of general settings with a valid private key assertion.
    *
@@ -37,13 +23,11 @@ describe('UsePrivateKeySpec', () => {
    * @doesNotPerformAssertions
    */
   it('testRetrievesGeneralSettingsWithValidAuth', async () => {
-    const tempFile = createTempJwtFile();
-    try {
-      const client = await Zitadel.withPrivateKey(env('BASE_URL'), tempFile);
-      await client.settings.settingsServiceGetGeneralSettings();
-    } finally {
-      fs.unlinkSync(tempFile); // Cleanup
-    }
+    const client = await Zitadel.withPrivateKey(
+      context.baseUrl,
+      context.jwtKey,
+    );
+    await client.settings.settingsServiceGetGeneralSettings();
   });
 
   /**
@@ -51,18 +35,12 @@ describe('UsePrivateKeySpec', () => {
    * @throws {Error}
    */
   it('testRaisesApiExceptionWithInvalidAuth', async () => {
-    const tempFile = createTempJwtFile();
-    try {
-      // Note: The original test uses a valid key with an invalid host.
-      const invalid = await Zitadel.withPrivateKey(
-        'https://zitadel.cloud',
-        tempFile,
-      );
-      await expect(
-        invalid.settings.settingsServiceGetGeneralSettings(),
-      ).rejects.toThrow(ZitadelException);
-    } finally {
-      fs.unlinkSync(tempFile); // Cleanup
-    }
+    const invalid = await Zitadel.withPrivateKey(
+      'https://zitadel.cloud',
+      context.jwtKey,
+    );
+    await expect(
+      invalid.settings.settingsServiceGetGeneralSettings(),
+    ).rejects.toThrow(ZitadelException);
   });
 });

--- a/spec/base-spec.ts
+++ b/spec/base-spec.ts
@@ -1,0 +1,204 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll } from '@jest/globals';
+import { setTimeout } from 'timers/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Defines the shape of the context object provided to tests.
+ */
+export interface TestContext {
+  authToken: string;
+  jwtKey: string;
+  baseUrl: string;
+}
+
+/**
+ * Abstract base class for integration tests that interact with a Docker
+ * Compose stack.
+ *
+ * This class handles the lifecycle of a Docker Compose environment,
+ * bringing it up before tests run and tearing it down afterward. It also
+ * provides mechanisms to load specific data (like authentication tokens
+ * and JWT keys) from files and make them accessible via protected getters
+ * for use in concrete test implementations.
+ */
+export abstract class AbstractIntegrationTest {
+  /**
+   * The authentication token loaded from a file.
+   */
+  protected static authToken: string | null = null;
+  /**
+   * The absolute path to the JWT key file.
+   */
+  protected static jwtKey: string | null = null;
+  /**
+   * The base URL for the services.
+   */
+  protected static baseUrl: string | null = null;
+  /**
+   * The absolute path to the docker-compose.yaml file.
+   */
+  private static composeFilePath: string = path.resolve(
+    __dirname,
+    '../etc/docker-compose.yaml',
+  );
+  /**
+   * The directory containing the docker-compose.yaml file.
+   */
+  private static composeFileDir: string | null = null;
+
+  /**
+   * Sets up the test environment before the first test in the class runs.
+   * This includes bringing up the Docker Compose stack and exposing
+   * necessary data.
+   */
+  public static async setUpBeforeClass(): Promise<void> {
+    this.composeFileDir = path.dirname(this.composeFilePath);
+
+    console.log('Bringing up Docker Compose stack...');
+    try {
+      const command = `docker compose -f "${this.composeFilePath}" up --detach --no-color --quiet-pull`;
+      execSync(command, { stdio: 'inherit' });
+      console.log('Docker Compose stack is up.');
+    } catch (error: unknown) {
+      let errorMessage = 'Failed to bring up Docker Compose stack.';
+      if (error instanceof Error) {
+        errorMessage += `\n${error.message}`;
+      }
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    this.loadFileContentIntoProperty('zitadel_output/pat.txt', 'authToken');
+
+    const jwtKeyFilePath = path.join(
+      this.composeFileDir,
+      'zitadel_output/sa-key.json',
+    );
+    if (!fs.existsSync(jwtKeyFilePath)) {
+      throw new Error(`JWT Key file not found at path: ${jwtKeyFilePath}`);
+    }
+    this.jwtKey = jwtKeyFilePath;
+    console.log(`Loaded JWT_KEY path: ${this.jwtKey}`);
+
+    this.baseUrl = 'http://localhost:8099';
+    console.log(`Exposed BASE_URL as: ${this.baseUrl}`);
+
+    console.log('Sleeping for 20 seconds to allow services to initialize...');
+    await setTimeout(20000);
+    console.log('Sleep finished.');
+  }
+
+  /**
+   * Reads the content of a file relative to the docker-compose file directory and
+   * assigns it to a specified static property of this class.
+   * This method is intended for loading *content*, not paths.
+   */
+  private static loadFileContentIntoProperty(
+    relativePath: string,
+    propertyName: 'authToken',
+  ): void {
+    if (!this.composeFileDir) {
+      throw new Error('Compose file directory is not initialized.');
+    }
+    const filePath = path.join(this.composeFileDir, relativePath);
+    if (fs.existsSync(filePath)) {
+      this[propertyName] = fs.readFileSync(filePath, 'utf-8').trim();
+      console.log(`Loaded ${filePath} content into property: ${propertyName}`);
+    } else {
+      throw new Error(
+        `File not found for property '${propertyName}': ${filePath}`,
+      );
+    }
+  }
+
+  /**
+   * Tears down the test environment after all tests in the class have run.
+   * This includes stopping and removing the Docker Compose stack.
+   */
+  public static tearDownAfterClass(): void {
+    console.log('Tearing down Docker Compose stack...');
+    if (fs.existsSync(this.composeFilePath)) {
+      try {
+        const command = `docker compose -f "${this.composeFilePath}" down -v`;
+        execSync(command, { stdio: 'inherit' });
+        console.log('Docker Compose stack torn down.');
+      } catch (error: unknown) {
+        let errorMessage = 'Warning: Failed to tear down Docker Compose stack.';
+        if (error instanceof Error) {
+          errorMessage += `\n${error.message}`;
+        }
+        console.error(errorMessage);
+      }
+    } else {
+      console.warn(
+        'Docker Compose file path not initialized or file does not exist, skipping tear down.',
+      );
+    }
+  }
+
+  /**
+   * Retrieves the authentication token.
+   */
+  public static getAuthToken(): string {
+    if (!this.authToken) throw new Error('Auth token is not available.');
+    return this.authToken;
+  }
+
+  /**
+   * Retrieves the absolute path to the JWT key file.
+   */
+  public static getJwtKey(): string {
+    if (!this.jwtKey) throw new Error('JWT key is not available.');
+    return this.jwtKey;
+  }
+
+  /**
+   * Retrieves the base URL.
+   */
+  public static getBaseUrl(): string {
+    if (!this.baseUrl) throw new Error('Base URL is not available.');
+    return this.baseUrl;
+  }
+}
+
+/**
+ * A Jest hook that manages the integration test environment lifecycle.
+ * It returns a Proxy object that allows for a `const` context declaration
+ * in your test files.
+ */
+export function useIntegrationEnvironment() {
+  let internalContext: TestContext | null = null;
+
+  beforeAll(async () => {
+    await AbstractIntegrationTest.setUpBeforeClass();
+    internalContext = {
+      authToken: AbstractIntegrationTest.getAuthToken(),
+      jwtKey: AbstractIntegrationTest.getJwtKey(),
+      baseUrl: AbstractIntegrationTest.getBaseUrl(),
+    };
+  }, 60000);
+
+  afterAll(() => {
+    AbstractIntegrationTest.tearDownAfterClass();
+    internalContext = null;
+  }, 60000);
+
+  const contextProxy = new Proxy<TestContext>({} as TestContext, {
+    get(_target, prop: keyof TestContext) {
+      if (!internalContext) {
+        throw new Error(
+          `The test context is not yet available. You can only access its properties (like '${String(prop)}') inside an 'it' block or a 'beforeEach'/'afterEach' hook.`,
+        );
+      }
+      return internalContext[prop];
+    },
+  });
+
+  return { context: contextProxy };
+}

--- a/spec/session-service-sanity.spec.ts
+++ b/spec/session-service-sanity.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/models/index.js';
 // noinspection ES6PreferShortImport
 import { ApiException } from '../src/api-exception.js';
+import { useIntegrationEnvironment } from './base-spec.js';
 
 /**
  * SessionService Integration Tests
@@ -24,30 +25,38 @@ import { ApiException } from '../src/api-exception.js';
  * and deleted after (afterEach) to ensure a clean state.
  */
 describe('SessionServiceSanityCheckSpec', () => {
+  const { context } = useIntegrationEnvironment();
   let client: Zitadel;
   let sessionId: string;
 
   // This runs once before all tests in the suite
   beforeAll(() => {
-    const validToken = process.env.AUTH_TOKEN as string;
-    const baseUrl = process.env.BASE_URL as string;
-    if (!validToken || !baseUrl) {
-      throw new Error(
-        'AUTH_TOKEN and BASE_URL environment variables must be set.',
-      );
-    }
-    client = Zitadel.withAccessToken(baseUrl, validToken);
+    client = Zitadel.withAccessToken(context.baseUrl, context.authToken);
   });
 
   /**
    * @throws ApiException
    */
   beforeEach(async () => {
+    const username = crypto.randomUUID().substring(0, 8);
+    await client.users.userServiceAddHumanUser({
+      userServiceAddHumanUserRequest: {
+        username: username,
+        profile: {
+          givenName: 'John',
+          familyName: 'Doe',
+        },
+        email: {
+          email: `johndoe_${username}@example.com`,
+        },
+      },
+    });
+
     const request = {
       sessionServiceCreateSessionRequest: {
         checks: {
           user: {
-            loginName: 'johndoe',
+            loginName: username,
           } as SessionServiceCheckUser,
         } as SessionServiceChecks,
         lifetime: '18000s',

--- a/spec/user-service-sanity.spec.ts
+++ b/spec/user-service-sanity.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/models/index.js';
 // noinspection ES6PreferShortImport
 import { ApiException } from '../src/api-exception.js';
+import { useIntegrationEnvironment } from './base-spec.js';
 
 /**
  * UserService Integration Tests
@@ -24,19 +25,13 @@ import { ApiException } from '../src/api-exception.js';
  * and removed after (afterEach) to ensure a clean state.
  */
 describe('UserServiceSanityCheckSpec', () => {
+  const { context } = useIntegrationEnvironment();
   let client: Zitadel;
   let user: UserServiceAddHumanUserResponse;
 
   // This runs once before all tests in the suite
   beforeAll(() => {
-    const validToken = process.env.AUTH_TOKEN as string;
-    const baseUrl = process.env.BASE_URL as string;
-    if (!validToken || !baseUrl) {
-      throw new Error(
-        'AUTH_TOKEN and BASE_URL environment variables must be set.',
-      );
-    }
-    client = Zitadel.withAccessToken(baseUrl, validToken);
+    client = Zitadel.withAccessToken(context.baseUrl, context.authToken);
   });
 
   /**


### PR DESCRIPTION
## Description

This PR refactors the integration test setup to use TestContainers with Docker Compose instead of relying on a production instance. It ensures that integration tests run in a controlled, versioned environment without requiring sensitive production tokens, and enables public contributors to successfully run the tests in their pull requests.

## Motivation and Context

The current integration tests depend on a production instance, causing issues such as failing public PR tests due to missing credentials and inconsistent environments. This change solves these problems by:
- Ensuring tests can run consistently on a versioned setup.
- Removing the need for sensitive production tokens.
- Enabling public contributions to pass the integration tests.
- Reducing reliance on external services for testing.

## How Has This Been Tested?

- **Local Testing:** I tested the new setup locally by running the integration tests using TestContainers with Docker Compose.
- **CI/CD Testing:** I updated the GitHub Actions CI/CD pipeline to spin up the necessary containers and run tests.
- **Integration with Existing Code:** Verified that the new setup does not break existing functionality and ensures all tests pass with the controlled test environment.

## Documentation:

N/A

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers.
- [x] I have checked the base branch of this pull request.
- [x] I have checked my code for any possible security vulnerabilities.