### PR TITLE
refactor: simplify SDK Public API

### DIFF
--- a/src/apis/ActionServiceApi.ts
+++ b/src/apis/ActionServiceApi.ts
@@ -105,7 +105,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * Create a new target to your endpoint, which can be used in executions.  Required permission:   - `action.target.write`  Required feature flag:   - `actions`
      * Create Target
      */
-    async actionServiceCreateTargetRaw(requestParameters: ActionServiceCreateTargetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaCreateTargetResponse>> {
+    private async actionServiceCreateTargetRaw(requestParameters: ActionServiceCreateTargetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaCreateTargetResponse>> {
         if (requestParameters['actionServiceCreateTargetRequest'] == null) {
             throw new runtime.RequiredError(
                 'actionServiceCreateTargetRequest',
@@ -151,7 +151,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * Delete an existing target. This will remove it from any configured execution as well. In case the target is not found, the request will return a successful response as the desired state is already achieved.  Required permission:   - `action.target.delete`  Required feature flag:   - `actions`
      * Delete Target
      */
-    async actionServiceDeleteTargetRaw(requestParameters: ActionServiceDeleteTargetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaDeleteTargetResponse>> {
+    private async actionServiceDeleteTargetRaw(requestParameters: ActionServiceDeleteTargetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaDeleteTargetResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',
@@ -194,7 +194,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * Returns the target identified by the requested ID.  Required permission:   - `action.target.read`  Required feature flag:   - `actions`
      * Get Target
      */
-    async actionServiceGetTargetRaw(requestParameters: ActionServiceGetTargetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaGetTargetResponse>> {
+    private async actionServiceGetTargetRaw(requestParameters: ActionServiceGetTargetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaGetTargetResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',
@@ -237,7 +237,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * List all available functions which can be used as condition for executions.
      * List Execution Functions
      */
-    async actionServiceListExecutionFunctionsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionFunctionsResponse>> {
+    private async actionServiceListExecutionFunctionsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionFunctionsResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -273,7 +273,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * List all available methods which can be used as condition for executions.
      * List Execution Methods
      */
-    async actionServiceListExecutionMethodsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionMethodsResponse>> {
+    private async actionServiceListExecutionMethodsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionMethodsResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -309,7 +309,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * List all available services which can be used as condition for executions.
      * List Execution Services
      */
-    async actionServiceListExecutionServicesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionServicesResponse>> {
+    private async actionServiceListExecutionServicesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionServicesResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -345,7 +345,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * List all matching executions. By default all executions of the instance are returned that have at least one execution target. Make sure to include a limit and sorting for pagination.  Required permission:   - `action.execution.read`  Required feature flag:   - `actions`
      * List Executions
      */
-    async actionServiceListExecutionsRaw(requestParameters: ActionServiceListExecutionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionsResponse>> {
+    private async actionServiceListExecutionsRaw(requestParameters: ActionServiceListExecutionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListExecutionsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['paginationOffset'] != null) {
@@ -397,7 +397,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * List all matching targets. By default all targets of the instance are returned. Make sure to include a limit and sorting for pagination.  Required permission:   - `action.target.read`  Required feature flag:   - `actions`
      * List targets
      */
-    async actionServiceListTargetsRaw(requestParameters: ActionServiceListTargetsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListTargetsResponse>> {
+    private async actionServiceListTargetsRaw(requestParameters: ActionServiceListTargetsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaListTargetsResponse>> {
         if (requestParameters['actionServiceListTargetsRequest'] == null) {
             throw new runtime.RequiredError(
                 'actionServiceListTargetsRequest',
@@ -443,7 +443,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * Sets an execution to call a target or include the targets of another execution. Setting an empty list of targets will remove all targets from the execution, making it a noop.  Required permission:   - `action.execution.write`  Required feature flag:   - `actions`
      * Set Execution
      */
-    async actionServiceSetExecutionRaw(requestParameters: ActionServiceSetExecutionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaSetExecutionResponse>> {
+    private async actionServiceSetExecutionRaw(requestParameters: ActionServiceSetExecutionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaSetExecutionResponse>> {
         if (requestParameters['actionServiceSetExecutionRequest'] == null) {
             throw new runtime.RequiredError(
                 'actionServiceSetExecutionRequest',
@@ -489,7 +489,7 @@ export class ActionServiceApi extends runtime.BaseAPI {
      * Update an existing target. To generate a new signing key set the optional expirationSigningKey.  Required permission:   - `action.target.write`  Required feature flag:   - `actions`
      * Update Target
      */
-    async actionServiceUpdateTargetRaw(requestParameters: ActionServiceUpdateTargetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaUpdateTargetResponse>> {
+    private async actionServiceUpdateTargetRaw(requestParameters: ActionServiceUpdateTargetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ActionServiceBetaUpdateTargetResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',

--- a/src/apis/FeatureServiceApi.ts
+++ b/src/apis/FeatureServiceApi.ts
@@ -111,7 +111,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Returns all configured features for an instance. Unset fields mean the feature is the current system default.  Required permissions:  - none
      * Get Instance Features
      */
-    async featureServiceGetInstanceFeaturesRaw(requestParameters: FeatureServiceGetInstanceFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetInstanceFeaturesResponse>> {
+    private async featureServiceGetInstanceFeaturesRaw(requestParameters: FeatureServiceGetInstanceFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetInstanceFeaturesResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['inheritance'] != null) {
@@ -151,7 +151,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Returns all configured features for an organization. Unset fields mean the feature is the current instance default.  Required permissions:  - org.feature.read  - no permission required for the organization the user belongs to
      * Get Organization Features
      */
-    async featureServiceGetOrganizationFeaturesRaw(requestParameters: FeatureServiceGetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetOrganizationFeaturesResponse>> {
+    private async featureServiceGetOrganizationFeaturesRaw(requestParameters: FeatureServiceGetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetOrganizationFeaturesResponse>> {
         if (requestParameters['organizationId'] == null) {
             throw new runtime.RequiredError(
                 'organizationId',
@@ -198,7 +198,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Returns all configured features for the system. Unset fields mean the feature is the current system default.  Required permissions:  - none
      * Get System Features
      */
-    async featureServiceGetSystemFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetSystemFeaturesResponse>> {
+    private async featureServiceGetSystemFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetSystemFeaturesResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -234,7 +234,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Returns all configured features for a user. Unset fields mean the feature is the current organization default.  Required permissions:  - user.feature.read  - no permission required for the own user
      * Get User Features
      */
-    async featureServiceGetUserFeaturesRaw(requestParameters: FeatureServiceGetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetUserFeaturesResponse>> {
+    private async featureServiceGetUserFeaturesRaw(requestParameters: FeatureServiceGetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceGetUserFeaturesResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -281,7 +281,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Deletes ALL configured features for an instance, reverting the behaviors to system defaults.  Required permissions:  - iam.feature.delete
      * Reset Instance Features
      */
-    async featureServiceResetInstanceFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetInstanceFeaturesResponse>> {
+    private async featureServiceResetInstanceFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetInstanceFeaturesResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -317,7 +317,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Deletes ALL configured features for an organization, reverting the behaviors to instance defaults.  Required permissions:  - org.feature.delete
      * Reset Organization Features
      */
-    async featureServiceResetOrganizationFeaturesRaw(requestParameters: FeatureServiceResetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetOrganizationFeaturesResponse>> {
+    private async featureServiceResetOrganizationFeaturesRaw(requestParameters: FeatureServiceResetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetOrganizationFeaturesResponse>> {
         if (requestParameters['organizationId'] == null) {
             throw new runtime.RequiredError(
                 'organizationId',
@@ -360,7 +360,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Deletes ALL configured features for the system, reverting the behaviors to system defaults.  Required permissions:  - system.feature.delete
      * Reset System Features
      */
-    async featureServiceResetSystemFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetSystemFeaturesResponse>> {
+    private async featureServiceResetSystemFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetSystemFeaturesResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -396,7 +396,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Deletes ALL configured features for a user, reverting the behaviors to organization defaults.  Required permissions:  - user.feature.delete
      * Reset User Features
      */
-    async featureServiceResetUserFeaturesRaw(requestParameters: FeatureServiceResetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetUserFeaturesResponse>> {
+    private async featureServiceResetUserFeaturesRaw(requestParameters: FeatureServiceResetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceResetUserFeaturesResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -439,7 +439,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Configure and set features that apply to a complete instance. Only fields present in the request are set or unset.  Required permissions:  - iam.feature.write
      * Set Instance Features
      */
-    async featureServiceSetInstanceFeaturesRaw(requestParameters: FeatureServiceSetInstanceFeaturesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetInstanceFeaturesResponse>> {
+    private async featureServiceSetInstanceFeaturesRaw(requestParameters: FeatureServiceSetInstanceFeaturesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetInstanceFeaturesResponse>> {
         if (requestParameters['featureServiceSetInstanceFeaturesRequest'] == null) {
             throw new runtime.RequiredError(
                 'featureServiceSetInstanceFeaturesRequest',
@@ -485,7 +485,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Configure and set features that apply to a complete instance. Only fields present in the request are set or unset.  Required permissions:  - org.feature.write
      * Set Organization Features
      */
-    async featureServiceSetOrganizationFeaturesRaw(requestParameters: FeatureServiceSetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetOrganizationFeaturesResponse>> {
+    private async featureServiceSetOrganizationFeaturesRaw(requestParameters: FeatureServiceSetOrganizationFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetOrganizationFeaturesResponse>> {
         if (requestParameters['organizationId'] == null) {
             throw new runtime.RequiredError(
                 'organizationId',
@@ -528,7 +528,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Configure and set features that apply to the complete system. Only fields present in the request are set or unset.  Required permissions:  - system.feature.write
      * Set System Features
      */
-    async featureServiceSetSystemFeaturesRaw(requestParameters: FeatureServiceSetSystemFeaturesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetSystemFeaturesResponse>> {
+    private async featureServiceSetSystemFeaturesRaw(requestParameters: FeatureServiceSetSystemFeaturesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetSystemFeaturesResponse>> {
         if (requestParameters['featureServiceSetSystemFeaturesRequest'] == null) {
             throw new runtime.RequiredError(
                 'featureServiceSetSystemFeaturesRequest',
@@ -574,7 +574,7 @@ export class FeatureServiceApi extends runtime.BaseAPI {
      * Configure and set features that apply to an user. Only fields present in the request are set or unset.  Required permissions:  - user.feature.write
      * Set User Features
      */
-    async featureServiceSetUserFeaturesRaw(requestParameters: FeatureServiceSetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetUserFeaturesResponse>> {
+    private async featureServiceSetUserFeaturesRaw(requestParameters: FeatureServiceSetUserFeaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureServiceSetUserFeaturesResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',

--- a/src/apis/IdentityProviderServiceApi.ts
+++ b/src/apis/IdentityProviderServiceApi.ts
@@ -38,7 +38,7 @@ export class IdentityProviderServiceApi extends runtime.BaseAPI {
      * Returns an identity provider (social/enterprise login) by its ID, which can be of the type Google, AzureAD, etc.
      * Get identity provider (IdP) by ID
      */
-    async identityProviderServiceGetIDPByIDRaw(requestParameters: IdentityProviderServiceGetIDPByIDRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IdentityProviderServiceGetIDPByIDResponse>> {
+    private async identityProviderServiceGetIDPByIDRaw(requestParameters: IdentityProviderServiceGetIDPByIDRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IdentityProviderServiceGetIDPByIDResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',

--- a/src/apis/OIDCServiceApi.ts
+++ b/src/apis/OIDCServiceApi.ts
@@ -64,7 +64,7 @@ export class OIDCServiceApi extends runtime.BaseAPI {
      * Authorize or deny the device authorization request based on the provided device authorization id.
      * Authorize or deny device authorization
      */
-    async oIDCServiceAuthorizeOrDenyDeviceAuthorizationRaw(requestParameters: OIDCServiceAuthorizeOrDenyDeviceAuthorizationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
+    private async oIDCServiceAuthorizeOrDenyDeviceAuthorizationRaw(requestParameters: OIDCServiceAuthorizeOrDenyDeviceAuthorizationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
         if (requestParameters['deviceAuthorizationId'] == null) {
             throw new runtime.RequiredError(
                 'deviceAuthorizationId',
@@ -117,7 +117,7 @@ export class OIDCServiceApi extends runtime.BaseAPI {
      * Finalize an Auth Request and get the callback URL for success or failure. The user must be redirected to the URL in order to inform the application about the success or failure. On success, the URL contains details for the application to obtain the tokens. This method can only be called once for an Auth request.
      * Finalize an Auth Request and get the callback URL.
      */
-    async oIDCServiceCreateCallbackRaw(requestParameters: OIDCServiceCreateCallbackOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceCreateCallbackResponse>> {
+    private async oIDCServiceCreateCallbackRaw(requestParameters: OIDCServiceCreateCallbackOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceCreateCallbackResponse>> {
         if (requestParameters['authRequestId'] == null) {
             throw new runtime.RequiredError(
                 'authRequestId',
@@ -170,7 +170,7 @@ export class OIDCServiceApi extends runtime.BaseAPI {
      * Get OIDC Auth Request details by ID, obtained from the redirect URL. Returns details that are parsed from the application\'s Auth Request.
      * Get OIDC Auth Request details
      */
-    async oIDCServiceGetAuthRequestRaw(requestParameters: OIDCServiceGetAuthRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceGetAuthRequestResponse>> {
+    private async oIDCServiceGetAuthRequestRaw(requestParameters: OIDCServiceGetAuthRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceGetAuthRequestResponse>> {
         if (requestParameters['authRequestId'] == null) {
             throw new runtime.RequiredError(
                 'authRequestId',
@@ -213,7 +213,7 @@ export class OIDCServiceApi extends runtime.BaseAPI {
      * Get the device authorization based on the provided \"user code\". This will return the device authorization request, which contains the device authorization id that is required to authorize the request once the user signed in or to deny it.
      * Get device authorization request
      */
-    async oIDCServiceGetDeviceAuthorizationRequestRaw(requestParameters: OIDCServiceGetDeviceAuthorizationRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceGetDeviceAuthorizationRequestResponse>> {
+    private async oIDCServiceGetDeviceAuthorizationRequestRaw(requestParameters: OIDCServiceGetDeviceAuthorizationRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OIDCServiceGetDeviceAuthorizationRequestResponse>> {
         if (requestParameters['userCode'] == null) {
             throw new runtime.RequiredError(
                 'userCode',

--- a/src/apis/OrganizationServiceApi.ts
+++ b/src/apis/OrganizationServiceApi.ts
@@ -51,7 +51,7 @@ export class OrganizationServiceApi extends runtime.BaseAPI {
      * Create a new organization with an administrative user. If no specific roles are sent for the users, they will be granted the role ORG_OWNER.
      * Create an Organization
      */
-    async organizationServiceAddOrganizationRaw(requestParameters: OrganizationServiceAddOrganizationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OrganizationServiceAddOrganizationResponse>> {
+    private async organizationServiceAddOrganizationRaw(requestParameters: OrganizationServiceAddOrganizationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OrganizationServiceAddOrganizationResponse>> {
         if (requestParameters['organizationServiceAddOrganizationRequest'] == null) {
             throw new runtime.RequiredError(
                 'organizationServiceAddOrganizationRequest',
@@ -97,7 +97,7 @@ export class OrganizationServiceApi extends runtime.BaseAPI {
      * Search for Organizations. By default, we will return all organization of the instance. Make sure to include a limit and sorting for pagination..
      * Search Organizations
      */
-    async organizationServiceListOrganizationsRaw(requestParameters: OrganizationServiceListOrganizationsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OrganizationServiceListOrganizationsResponse>> {
+    private async organizationServiceListOrganizationsRaw(requestParameters: OrganizationServiceListOrganizationsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OrganizationServiceListOrganizationsResponse>> {
         if (requestParameters['organizationServiceListOrganizationsRequest'] == null) {
             throw new runtime.RequiredError(
                 'organizationServiceListOrganizationsRequest',

--- a/src/apis/SAMLServiceApi.ts
+++ b/src/apis/SAMLServiceApi.ts
@@ -49,7 +49,7 @@ export class SAMLServiceApi extends runtime.BaseAPI {
      * Finalize a SAML Request and get the response definition for success or failure. The response must be handled as per the SAML definition to inform the application about the success or failure. On success, the response contains details for the application to obtain the SAMLResponse. This method can only be called once for an SAML request.
      * Finalize a SAML Request and get the response.
      */
-    async sAMLServiceCreateResponseRaw(requestParameters: SAMLServiceCreateResponseOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SAMLServiceCreateResponseResponse>> {
+    private async sAMLServiceCreateResponseRaw(requestParameters: SAMLServiceCreateResponseOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SAMLServiceCreateResponseResponse>> {
         if (requestParameters['samlRequestId'] == null) {
             throw new runtime.RequiredError(
                 'samlRequestId',
@@ -102,7 +102,7 @@ export class SAMLServiceApi extends runtime.BaseAPI {
      * Get SAML Request details by ID. Returns details that are parsed from the application\'s SAML Request.
      * Get SAML Request details
      */
-    async sAMLServiceGetSAMLRequestRaw(requestParameters: SAMLServiceGetSAMLRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SAMLServiceGetSAMLRequestResponse>> {
+    private async sAMLServiceGetSAMLRequestRaw(requestParameters: SAMLServiceGetSAMLRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SAMLServiceGetSAMLRequestResponse>> {
         if (requestParameters['samlRequestId'] == null) {
             throw new runtime.RequiredError(
                 'samlRequestId',

--- a/src/apis/SessionServiceApi.ts
+++ b/src/apis/SessionServiceApi.ts
@@ -81,7 +81,7 @@ export class SessionServiceApi extends runtime.BaseAPI {
      * Create a new session. A token will be returned, which is required for further updates of the session.
      * Create a new session
      */
-    async sessionServiceCreateSessionRaw(requestParameters: SessionServiceCreateSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceCreateSessionResponse>> {
+    private async sessionServiceCreateSessionRaw(requestParameters: SessionServiceCreateSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceCreateSessionResponse>> {
         if (requestParameters['sessionServiceCreateSessionRequest'] == null) {
             throw new runtime.RequiredError(
                 'sessionServiceCreateSessionRequest',
@@ -127,7 +127,7 @@ export class SessionServiceApi extends runtime.BaseAPI {
      * Terminate your own session or if granted any other session.
      * Terminate an existing session
      */
-    async sessionServiceDeleteSessionRaw(requestParameters: SessionServiceDeleteSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceDeleteSessionResponse>> {
+    private async sessionServiceDeleteSessionRaw(requestParameters: SessionServiceDeleteSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceDeleteSessionResponse>> {
         if (requestParameters['sessionId'] == null) {
             throw new runtime.RequiredError(
                 'sessionId',
@@ -180,7 +180,7 @@ export class SessionServiceApi extends runtime.BaseAPI {
      * Get a session and all its information like the time of the user or password verification
      * Get a session
      */
-    async sessionServiceGetSessionRaw(requestParameters: SessionServiceGetSessionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceGetSessionResponse>> {
+    private async sessionServiceGetSessionRaw(requestParameters: SessionServiceGetSessionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceGetSessionResponse>> {
         if (requestParameters['sessionId'] == null) {
             throw new runtime.RequiredError(
                 'sessionId',
@@ -227,7 +227,7 @@ export class SessionServiceApi extends runtime.BaseAPI {
      * Search for sessions
      * Search sessions
      */
-    async sessionServiceListSessionsRaw(requestParameters: SessionServiceListSessionsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceListSessionsResponse>> {
+    private async sessionServiceListSessionsRaw(requestParameters: SessionServiceListSessionsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceListSessionsResponse>> {
         if (requestParameters['sessionServiceListSessionsRequest'] == null) {
             throw new runtime.RequiredError(
                 'sessionServiceListSessionsRequest',
@@ -273,7 +273,7 @@ export class SessionServiceApi extends runtime.BaseAPI {
      * Update an existing session with new information.
      * Update an existing session
      */
-    async sessionServiceSetSessionRaw(requestParameters: SessionServiceSetSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceSetSessionResponse>> {
+    private async sessionServiceSetSessionRaw(requestParameters: SessionServiceSetSessionOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SessionServiceSetSessionResponse>> {
         if (requestParameters['sessionId'] == null) {
             throw new runtime.RequiredError(
                 'sessionId',

--- a/src/apis/SettingsServiceApi.ts
+++ b/src/apis/SettingsServiceApi.ts
@@ -115,7 +115,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the current active identity providers for the requested context
      * Get the current active identity providers
      */
-    async settingsServiceGetActiveIdentityProvidersRaw(requestParameters: SettingsServiceGetActiveIdentityProvidersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetActiveIdentityProvidersResponse>> {
+    private async settingsServiceGetActiveIdentityProvidersRaw(requestParameters: SettingsServiceGetActiveIdentityProvidersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetActiveIdentityProvidersResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -175,7 +175,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the current active branding settings for the requested context
      * Get the current active branding settings
      */
-    async settingsServiceGetBrandingSettingsRaw(requestParameters: SettingsServiceGetBrandingSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetBrandingSettingsResponse>> {
+    private async settingsServiceGetBrandingSettingsRaw(requestParameters: SettingsServiceGetBrandingSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetBrandingSettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -219,7 +219,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the domain settings for the requested context
      * Get the domain settings
      */
-    async settingsServiceGetDomainSettingsRaw(requestParameters: SettingsServiceGetDomainSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetDomainSettingsResponse>> {
+    private async settingsServiceGetDomainSettingsRaw(requestParameters: SettingsServiceGetDomainSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetDomainSettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -263,7 +263,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the basic information of the instance for the requested context
      * Get basic information over the instance
      */
-    async settingsServiceGetGeneralSettingsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetGeneralSettingsResponse>> {
+    private async settingsServiceGetGeneralSettingsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetGeneralSettingsResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -299,7 +299,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the legal settings for the requested context
      * Get the legal and support settings
      */
-    async settingsServiceGetLegalAndSupportSettingsRaw(requestParameters: SettingsServiceGetLegalAndSupportSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLegalAndSupportSettingsResponse>> {
+    private async settingsServiceGetLegalAndSupportSettingsRaw(requestParameters: SettingsServiceGetLegalAndSupportSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLegalAndSupportSettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -343,7 +343,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the lockout settings for the requested context, which define when a user will be locked
      * Get the lockout settings
      */
-    async settingsServiceGetLockoutSettingsRaw(requestParameters: SettingsServiceGetLockoutSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLockoutSettingsResponse>> {
+    private async settingsServiceGetLockoutSettingsRaw(requestParameters: SettingsServiceGetLockoutSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLockoutSettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -387,7 +387,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the settings for the requested context
      * Get the login settings
      */
-    async settingsServiceGetLoginSettingsRaw(requestParameters: SettingsServiceGetLoginSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLoginSettingsResponse>> {
+    private async settingsServiceGetLoginSettingsRaw(requestParameters: SettingsServiceGetLoginSettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetLoginSettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -431,7 +431,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the password complexity settings for the requested context
      * Get the password complexity settings
      */
-    async settingsServiceGetPasswordComplexitySettingsRaw(requestParameters: SettingsServiceGetPasswordComplexitySettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetPasswordComplexitySettingsResponse>> {
+    private async settingsServiceGetPasswordComplexitySettingsRaw(requestParameters: SettingsServiceGetPasswordComplexitySettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetPasswordComplexitySettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -475,7 +475,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Return the password expiry settings for the requested context
      * Get the password expiry settings
      */
-    async settingsServiceGetPasswordExpirySettingsRaw(requestParameters: SettingsServiceGetPasswordExpirySettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetPasswordExpirySettingsResponse>> {
+    private async settingsServiceGetPasswordExpirySettingsRaw(requestParameters: SettingsServiceGetPasswordExpirySettingsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetPasswordExpirySettingsResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters['ctxOrgId'] != null) {
@@ -519,7 +519,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Returns the security settings of the ZITADEL instance.
      * Get Security Settings
      */
-    async settingsServiceGetSecuritySettingsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetSecuritySettingsResponse>> {
+    private async settingsServiceGetSecuritySettingsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceGetSecuritySettingsResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -555,7 +555,7 @@ export class SettingsServiceApi extends runtime.BaseAPI {
      * Set the security settings of the ZITADEL instance.
      * Set Security Settings
      */
-    async settingsServiceSetSecuritySettingsRaw(requestParameters: SettingsServiceSetSecuritySettingsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceSetSecuritySettingsResponse>> {
+    private async settingsServiceSetSecuritySettingsRaw(requestParameters: SettingsServiceSetSecuritySettingsOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SettingsServiceSetSecuritySettingsResponse>> {
         if (requestParameters['settingsServiceSetSecuritySettingsRequest'] == null) {
             throw new runtime.RequiredError(
                 'settingsServiceSetSecuritySettingsRequest',

--- a/src/apis/UserServiceApi.ts
+++ b/src/apis/UserServiceApi.ts
@@ -449,7 +449,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Create/import a new user with the type human. The newly created user will get a verification email if either the email address is not marked as verified and you did not request the verification to be returned.
      * Create a new human user
      */
-    async userServiceAddHumanUserRaw(requestParameters: UserServiceAddHumanUserOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddHumanUserResponse>> {
+    private async userServiceAddHumanUserRaw(requestParameters: UserServiceAddHumanUserOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddHumanUserResponse>> {
         if (requestParameters['userServiceAddHumanUserRequest'] == null) {
             throw new runtime.RequiredError(
                 'userServiceAddHumanUserRequest',
@@ -495,7 +495,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Add link to an identity provider to an user..
      * Add link to an identity provider to an user
      */
-    async userServiceAddIDPLinkRaw(requestParameters: UserServiceAddIDPLinkOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddIDPLinkResponse>> {
+    private async userServiceAddIDPLinkRaw(requestParameters: UserServiceAddIDPLinkOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddIDPLinkResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -548,7 +548,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Add a new One-Time Password (OTP) Email factor to the authenticated user. OTP Email will enable the user to verify a OTP with the latest verified email. The email has to be verified to add the second factor..
      * Add OTP Email for a user
      */
-    async userServiceAddOTPEmailRaw(requestParameters: UserServiceAddOTPEmailRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddOTPEmailResponse>> {
+    private async userServiceAddOTPEmailRaw(requestParameters: UserServiceAddOTPEmailRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddOTPEmailResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -591,7 +591,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Add a new One-Time Password (OTP) SMS factor to the authenticated user. OTP SMS will enable the user to verify a OTP with the latest verified phone number. The phone number has to be verified to add the second factor..
      * Add OTP SMS for a user
      */
-    async userServiceAddOTPSMSRaw(requestParameters: UserServiceAddOTPSMSRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddOTPSMSResponse>> {
+    private async userServiceAddOTPSMSRaw(requestParameters: UserServiceAddOTPSMSRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceAddOTPSMSResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -634,7 +634,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Create an invite code for a user to initialize their first authentication method (password, passkeys, IdP) depending on the organization\'s available methods.
      * Create an invite code for a user
      */
-    async userServiceCreateInviteCodeRaw(requestParameters: UserServiceCreateInviteCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceCreateInviteCodeResponse>> {
+    private async userServiceCreateInviteCodeRaw(requestParameters: UserServiceCreateInviteCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceCreateInviteCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -687,7 +687,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Create a passkey registration link which includes a code and either return it or send it to the user..
      * Create a passkey registration link for a user
      */
-    async userServiceCreatePasskeyRegistrationLinkRaw(requestParameters: UserServiceCreatePasskeyRegistrationLinkOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceCreatePasskeyRegistrationLinkResponse>> {
+    private async userServiceCreatePasskeyRegistrationLinkRaw(requestParameters: UserServiceCreatePasskeyRegistrationLinkOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceCreatePasskeyRegistrationLinkResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -740,7 +740,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * The state of the user will be changed to \'deactivated\'. The user will not be able to log in anymore. The endpoint returns an error if the user is already in the state \'deactivated\'. Use deactivate user when the user should not be able to use the account anymore, but you still need access to the user data..
      * Deactivate user
      */
-    async userServiceDeactivateUserRaw(requestParameters: UserServiceDeactivateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceDeactivateUserResponse>> {
+    private async userServiceDeactivateUserRaw(requestParameters: UserServiceDeactivateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceDeactivateUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -783,7 +783,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * The state of the user will be changed to \'deleted\'. The user will not be able to log in anymore. Endpoints requesting this user will return an error \'User not found..
      * Delete user
      */
-    async userServiceDeleteUserRaw(requestParameters: UserServiceDeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceDeleteUserResponse>> {
+    private async userServiceDeleteUserRaw(requestParameters: UserServiceDeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceDeleteUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -826,7 +826,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Returns the full user object (human or machine) including the profile, email, etc..
      * User by ID
      */
-    async userServiceGetUserByIDRaw(requestParameters: UserServiceGetUserByIDRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceGetUserByIDResponse>> {
+    private async userServiceGetUserByIDRaw(requestParameters: UserServiceGetUserByIDRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceGetUserByIDResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -869,7 +869,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Update the last time the user has skipped MFA initialization. The server timestamp is used.
      * MFA Init Skipped
      */
-    async userServiceHumanMFAInitSkippedRaw(requestParameters: UserServiceHumanMFAInitSkippedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceHumanMFAInitSkippedResponse>> {
+    private async userServiceHumanMFAInitSkippedRaw(requestParameters: UserServiceHumanMFAInitSkippedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceHumanMFAInitSkippedResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -910,7 +910,7 @@ export class UserServiceApi extends runtime.BaseAPI {
 
     /**
      */
-    async userServiceListAuthenticationFactorsRaw(requestParameters: UserServiceListAuthenticationFactorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListAuthenticationFactorsResponse>> {
+    private async userServiceListAuthenticationFactorsRaw(requestParameters: UserServiceListAuthenticationFactorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListAuthenticationFactorsResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -959,7 +959,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * List all possible authentication methods of a user like password, passwordless, (T)OTP and more..
      * List all possible authentication methods of a user
      */
-    async userServiceListAuthenticationMethodTypesRaw(requestParameters: UserServiceListAuthenticationMethodTypesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListAuthenticationMethodTypesResponse>> {
+    private async userServiceListAuthenticationMethodTypesRaw(requestParameters: UserServiceListAuthenticationMethodTypesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListAuthenticationMethodTypesResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1010,7 +1010,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * List links to an identity provider of an user.
      * List links to an identity provider of an user
      */
-    async userServiceListIDPLinksRaw(requestParameters: UserServiceListIDPLinksOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListIDPLinksResponse>> {
+    private async userServiceListIDPLinksRaw(requestParameters: UserServiceListIDPLinksOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListIDPLinksResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1063,7 +1063,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * List passkeys of an user
      * List passkeys of an user
      */
-    async userServiceListPasskeysRaw(requestParameters: UserServiceListPasskeysRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListPasskeysResponse>> {
+    private async userServiceListPasskeysRaw(requestParameters: UserServiceListPasskeysRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListPasskeysResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1106,7 +1106,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Search for users. By default, we will return all users of your instance that you have permission to read. Make sure to include a limit and sorting for pagination.
      * Search Users
      */
-    async userServiceListUsersRaw(requestParameters: UserServiceListUsersOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListUsersResponse>> {
+    private async userServiceListUsersRaw(requestParameters: UserServiceListUsersOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceListUsersResponse>> {
         if (requestParameters['userServiceListUsersRequest'] == null) {
             throw new runtime.RequiredError(
                 'userServiceListUsersRequest',
@@ -1152,7 +1152,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * The state of the user will be changed to \'locked\'. The user will not be able to log in anymore. The endpoint returns an error if the user is already in the state \'locked\'. Use this endpoint if the user should not be able to log in temporarily because of an event that happened (wrong password, etc.)..
      * Lock user
      */
-    async userServiceLockUserRaw(requestParameters: UserServiceLockUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceLockUserResponse>> {
+    private async userServiceLockUserRaw(requestParameters: UserServiceLockUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceLockUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1195,7 +1195,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Request a code to reset a password..
      * Request a code to reset a password
      */
-    async userServicePasswordResetRaw(requestParameters: UserServicePasswordResetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServicePasswordResetResponse>> {
+    private async userServicePasswordResetRaw(requestParameters: UserServicePasswordResetOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServicePasswordResetResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1248,7 +1248,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Reactivate a user with the state \'deactivated\'. The user will be able to log in again afterward. The endpoint returns an error if the user is not in the state \'deactivated\'..
      * Reactivate user
      */
-    async userServiceReactivateUserRaw(requestParameters: UserServiceReactivateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceReactivateUserResponse>> {
+    private async userServiceReactivateUserRaw(requestParameters: UserServiceReactivateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceReactivateUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1291,7 +1291,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Start the registration of a passkey for a user, as a response the public key credential creation options are returned, which are used to verify the passkey..
      * Start the registration of passkey for a user
      */
-    async userServiceRegisterPasskeyRaw(requestParameters: UserServiceRegisterPasskeyOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterPasskeyResponse>> {
+    private async userServiceRegisterPasskeyRaw(requestParameters: UserServiceRegisterPasskeyOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterPasskeyResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1344,7 +1344,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Start the registration of a TOTP generator for a user, as a response a secret returned, which is used to initialize a TOTP app or device..
      * Start the registration of a TOTP generator for a user
      */
-    async userServiceRegisterTOTPRaw(requestParameters: UserServiceRegisterTOTPRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterTOTPResponse>> {
+    private async userServiceRegisterTOTPRaw(requestParameters: UserServiceRegisterTOTPRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterTOTPResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1387,7 +1387,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Start the registration of a u2f token for a user, as a response the public key credential creation options are returned, which are used to verify the u2f token..
      * Start the registration of a u2f token for a user
      */
-    async userServiceRegisterU2FRaw(requestParameters: UserServiceRegisterU2FOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterU2FResponse>> {
+    private async userServiceRegisterU2FRaw(requestParameters: UserServiceRegisterU2FOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRegisterU2FResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1440,7 +1440,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove link of an identity provider to an user.
      * Remove link of an identity provider to an user
      */
-    async userServiceRemoveIDPLinkRaw(requestParameters: UserServiceRemoveIDPLinkRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveIDPLinkResponse>> {
+    private async userServiceRemoveIDPLinkRaw(requestParameters: UserServiceRemoveIDPLinkRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveIDPLinkResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1497,7 +1497,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove the configured One-Time Password (OTP) Email factor of a user. As only one OTP Email per user is allowed, the user will not have OTP Email as a second factor afterward.
      * Remove One-Time Password (OTP) Email from a user
      */
-    async userServiceRemoveOTPEmailRaw(requestParameters: UserServiceRemoveOTPEmailRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveOTPEmailResponse>> {
+    private async userServiceRemoveOTPEmailRaw(requestParameters: UserServiceRemoveOTPEmailRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveOTPEmailResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1540,7 +1540,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove the configured One-Time Password (OTP) SMS factor of a user. As only one OTP SMS per user is allowed, the user will not have OTP SMS as a second factor afterward.
      * Remove One-Time Password (OTP) SMS from a user
      */
-    async userServiceRemoveOTPSMSRaw(requestParameters: UserServiceRemoveOTPSMSRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveOTPSMSResponse>> {
+    private async userServiceRemoveOTPSMSRaw(requestParameters: UserServiceRemoveOTPSMSRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveOTPSMSResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1583,7 +1583,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove passkey from a user.
      * Remove passkey from a user
      */
-    async userServiceRemovePasskeyRaw(requestParameters: UserServiceRemovePasskeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemovePasskeyResponse>> {
+    private async userServiceRemovePasskeyRaw(requestParameters: UserServiceRemovePasskeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemovePasskeyResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1633,7 +1633,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Delete the phone number of a user.
      * Delete the user phone
      */
-    async userServiceRemovePhoneRaw(requestParameters: UserServiceRemovePhoneRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemovePhoneResponse>> {
+    private async userServiceRemovePhoneRaw(requestParameters: UserServiceRemovePhoneRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemovePhoneResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1676,7 +1676,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove the configured TOTP generator of a user. As only one TOTP generator per user is allowed, the user will not have TOTP as a second factor afterward.
      * Remove TOTP generator from a user
      */
-    async userServiceRemoveTOTPRaw(requestParameters: UserServiceRemoveTOTPRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveTOTPResponse>> {
+    private async userServiceRemoveTOTPRaw(requestParameters: UserServiceRemoveTOTPRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveTOTPResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1719,7 +1719,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Remove u2f token from a user
      * Remove u2f token from a user
      */
-    async userServiceRemoveU2FRaw(requestParameters: UserServiceRemoveU2FRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveU2FResponse>> {
+    private async userServiceRemoveU2FRaw(requestParameters: UserServiceRemoveU2FRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRemoveU2FResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1769,7 +1769,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Resend code to verify user email.
      * Resend code to verify user email
      */
-    async userServiceResendEmailCodeRaw(requestParameters: UserServiceResendEmailCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendEmailCodeResponse>> {
+    private async userServiceResendEmailCodeRaw(requestParameters: UserServiceResendEmailCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendEmailCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1822,7 +1822,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Resend an invite code for a user to initialize their first authentication method (password, passkeys, IdP) depending on the organization\'s available methods. A resend is only possible if a code has been created previously and sent to the user. If there is no code or it was directly returned, an error will be returned.
      * Resend an invite code for a user
      */
-    async userServiceResendInviteCodeRaw(requestParameters: UserServiceResendInviteCodeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendInviteCodeResponse>> {
+    private async userServiceResendInviteCodeRaw(requestParameters: UserServiceResendInviteCodeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendInviteCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1865,7 +1865,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Resend code to verify user phone.
      * Resend code to verify user phone
      */
-    async userServiceResendPhoneCodeRaw(requestParameters: UserServiceResendPhoneCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendPhoneCodeResponse>> {
+    private async userServiceResendPhoneCodeRaw(requestParameters: UserServiceResendPhoneCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceResendPhoneCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -1918,7 +1918,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Retrieve the information returned by the identity provider for registration or updating an existing user with new information..
      * Retrieve the information returned by the identity provider
      */
-    async userServiceRetrieveIdentityProviderIntentRaw(requestParameters: UserServiceRetrieveIdentityProviderIntentOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRetrieveIdentityProviderIntentResponse>> {
+    private async userServiceRetrieveIdentityProviderIntentRaw(requestParameters: UserServiceRetrieveIdentityProviderIntentOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceRetrieveIdentityProviderIntentResponse>> {
         if (requestParameters['idpIntentId'] == null) {
             throw new runtime.RequiredError(
                 'idpIntentId',
@@ -1971,7 +1971,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Send code to verify user email.
      * Send code to verify user email
      */
-    async userServiceSendEmailCodeRaw(requestParameters: UserServiceSendEmailCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSendEmailCodeResponse>> {
+    private async userServiceSendEmailCodeRaw(requestParameters: UserServiceSendEmailCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSendEmailCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2024,7 +2024,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Change the email address of a user. If the state is set to not verified, a verification code will be generated, which can be either returned or sent to the user by email..
      * Change the user email
      */
-    async userServiceSetEmailRaw(requestParameters: UserServiceSetEmailOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetEmailResponse>> {
+    private async userServiceSetEmailRaw(requestParameters: UserServiceSetEmailOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetEmailResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2077,7 +2077,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Change the password of a user with either a verification code or the current password..
      * Change password
      */
-    async userServiceSetPasswordRaw(requestParameters: UserServiceSetPasswordOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetPasswordResponse>> {
+    private async userServiceSetPasswordRaw(requestParameters: UserServiceSetPasswordOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetPasswordResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2130,7 +2130,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Set the phone number of a user. If the state is set to not verified, a verification code will be generated, which can be either returned or sent to the user by sms..
      * Set the user phone
      */
-    async userServiceSetPhoneRaw(requestParameters: UserServiceSetPhoneOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetPhoneResponse>> {
+    private async userServiceSetPhoneRaw(requestParameters: UserServiceSetPhoneOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceSetPhoneResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2183,7 +2183,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Start a flow with an identity provider, for external login, registration or linking..
      * Start flow with an identity provider
      */
-    async userServiceStartIdentityProviderIntentRaw(requestParameters: UserServiceStartIdentityProviderIntentOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceStartIdentityProviderIntentResponse>> {
+    private async userServiceStartIdentityProviderIntentRaw(requestParameters: UserServiceStartIdentityProviderIntentOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceStartIdentityProviderIntentResponse>> {
         if (requestParameters['userServiceStartIdentityProviderIntentRequest'] == null) {
             throw new runtime.RequiredError(
                 'userServiceStartIdentityProviderIntentRequest',
@@ -2229,7 +2229,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * The state of the user will be changed to \'locked\'. The user will not be able to log in anymore. The endpoint returns an error if the user is already in the state \'locked\'. Use this endpoint if the user should not be able to log in temporarily because of an event that happened (wrong password, etc.)..
      * Unlock user
      */
-    async userServiceUnlockUserRaw(requestParameters: UserServiceUnlockUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceUnlockUserResponse>> {
+    private async userServiceUnlockUserRaw(requestParameters: UserServiceUnlockUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceUnlockUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2272,7 +2272,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Update all information from a user..
      * Update User
      */
-    async userServiceUpdateHumanUserRaw(requestParameters: UserServiceUpdateHumanUserOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceUpdateHumanUserResponse>> {
+    private async userServiceUpdateHumanUserRaw(requestParameters: UserServiceUpdateHumanUserOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceUpdateHumanUserResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2325,7 +2325,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the email with the generated code.
      * Verify the email
      */
-    async userServiceVerifyEmailRaw(requestParameters: UserServiceVerifyEmailOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyEmailResponse>> {
+    private async userServiceVerifyEmailRaw(requestParameters: UserServiceVerifyEmailOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyEmailResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2378,7 +2378,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the invite code of a user previously issued. This will set their email to a verified state and allow the user to set up their first authentication method (password, passkeys, IdP) depending on the organization\'s available methods.
      * Verify an invite code for a user
      */
-    async userServiceVerifyInviteCodeRaw(requestParameters: UserServiceVerifyInviteCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyInviteCodeResponse>> {
+    private async userServiceVerifyInviteCodeRaw(requestParameters: UserServiceVerifyInviteCodeOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyInviteCodeResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2431,7 +2431,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the passkey registration with the public key credential..
      * Verify a passkey for a user
      */
-    async userServiceVerifyPasskeyRegistrationRaw(requestParameters: UserServiceVerifyPasskeyRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyPasskeyRegistrationResponse>> {
+    private async userServiceVerifyPasskeyRegistrationRaw(requestParameters: UserServiceVerifyPasskeyRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyPasskeyRegistrationResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2491,7 +2491,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the phone with the generated code..
      * Verify the phone
      */
-    async userServiceVerifyPhoneRaw(requestParameters: UserServiceVerifyPhoneOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyPhoneResponse>> {
+    private async userServiceVerifyPhoneRaw(requestParameters: UserServiceVerifyPhoneOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyPhoneResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2544,7 +2544,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the TOTP registration with a generated code..
      * Verify a TOTP generator for a user
      */
-    async userServiceVerifyTOTPRegistrationRaw(requestParameters: UserServiceVerifyTOTPRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyTOTPRegistrationResponse>> {
+    private async userServiceVerifyTOTPRegistrationRaw(requestParameters: UserServiceVerifyTOTPRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyTOTPRegistrationResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',
@@ -2597,7 +2597,7 @@ export class UserServiceApi extends runtime.BaseAPI {
      * Verify the u2f token registration with the public key credential..
      * Verify a u2f token for a user
      */
-    async userServiceVerifyU2FRegistrationRaw(requestParameters: UserServiceVerifyU2FRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyU2FRegistrationResponse>> {
+    private async userServiceVerifyU2FRegistrationRaw(requestParameters: UserServiceVerifyU2FRegistrationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserServiceVerifyU2FRegistrationResponse>> {
         if (requestParameters['userId'] == null) {
             throw new runtime.RequiredError(
                 'userId',

--- a/src/apis/WebKeyServiceApi.ts
+++ b/src/apis/WebKeyServiceApi.ts
@@ -58,7 +58,7 @@ export class WebKeyServiceApi extends runtime.BaseAPI {
      * Switch the active signing web key. The previously active key will be deactivated. Note that the JWKs OIDC endpoint returns a cacheable response. Therefore it is not advised to activate a key that has been created within the cache duration (default is 5min), as the public key may not have been propagated to caches and clients yet.  Required permission:   - `iam.web_key.write`  Required feature flag:   - `web_key`
      * Activate Web Key
      */
-    async webKeyServiceActivateWebKeyRaw(requestParameters: WebKeyServiceActivateWebKeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaActivateWebKeyResponse>> {
+    private async webKeyServiceActivateWebKeyRaw(requestParameters: WebKeyServiceActivateWebKeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaActivateWebKeyResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',
@@ -101,7 +101,7 @@ export class WebKeyServiceApi extends runtime.BaseAPI {
      * Generate a private and public key pair. The private key can be used to sign OIDC tokens after activation. The public key can be used to validate OIDC tokens. The newly created key will have the state `STATE_INITIAL` and is published to the public key endpoint. Note that the JWKs OIDC endpoint returns a cacheable response.  If no key type is provided, a RSA key pair with 2048 bits and SHA256 hashing will be created.  Required permission:   - `iam.web_key.write`  Required feature flag:   - `web_key`
      * Create Web Key
      */
-    async webKeyServiceCreateWebKeyRaw(requestParameters: WebKeyServiceCreateWebKeyOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaCreateWebKeyResponse>> {
+    private async webKeyServiceCreateWebKeyRaw(requestParameters: WebKeyServiceCreateWebKeyOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaCreateWebKeyResponse>> {
         if (requestParameters['webKeyServiceCreateWebKeyRequest'] == null) {
             throw new runtime.RequiredError(
                 'webKeyServiceCreateWebKeyRequest',
@@ -147,7 +147,7 @@ export class WebKeyServiceApi extends runtime.BaseAPI {
      * Delete a web key pair. Only inactive keys can be deleted. Once a key is deleted, any tokens signed by this key will be invalid. Note that the JWKs OIDC endpoint returns a cacheable response. In case the web key is not found, the request will return a successful response as the desired state is already achieved. You can check the change date in the response to verify if the web key was deleted during the request.  Required permission:   - `iam.web_key.delete`  Required feature flag:   - `web_key`
      * Delete Web Key
      */
-    async webKeyServiceDeleteWebKeyRaw(requestParameters: WebKeyServiceDeleteWebKeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaDeleteWebKeyResponse>> {
+    private async webKeyServiceDeleteWebKeyRaw(requestParameters: WebKeyServiceDeleteWebKeyRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaDeleteWebKeyResponse>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',
@@ -190,7 +190,7 @@ export class WebKeyServiceApi extends runtime.BaseAPI {
      * List all web keys and their states.  Required permission:   - `iam.web_key.read`  Required feature flag:   - `web_key`
      * List Web Keys
      */
-    async webKeyServiceListWebKeysRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaListWebKeysResponse>> {
+    private async webKeyServiceListWebKeysRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<WebKeyServiceBetaListWebKeysResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
## Description

This PR cleans up the public API in our generated SDK.

Helper methods like `...Raw`, `...withHttpInfo`, or those with extra header parameters are now private. This leaves a single, simple public method for each API operation.

## Related Issue

This change makes our SDKs much easier and more intuitive for developers to use. The previous design exposed multiple internal methods, cluttering the API and causing confusion. This cleanup provides a simple and obvious entry point for every API call.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

* All SDKs were regenerated using the new, cleaner templates.
* All existing unit and integration tests were run against the new code and passed, confirming that no functionality was broken.

## Documentation:

The generated code documentation is now cleaner by default. No other documentation changes are needed.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
