### PR TITLE
chore(deps): resolve tar-fs symlink validation bypass vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@semantic-release/github": "^11.0.6",
         "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.1.0",
-        "@tsconfig/node20": "*",
+        "@tsconfig/node20": "latest",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.6.2",
         "dotenv": "^17.2.3",
@@ -33,7 +33,7 @@
         "jest-junit": "^16.0.0",
         "knip": "^5.64.1",
         "prettier": "^3.6.2",
-        "testcontainers": "^11.7.0",
+        "testcontainers": "^11.7.1",
         "ts-jest": "^29.4.4",
         "typescript": "^5.9.3"
       },
@@ -16514,9 +16514,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16653,9 +16653,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.7.0.tgz",
-      "integrity": "sha512-uImnn8TqYfjv/e+McPBpBqKWvWKPIPzKtL+jxHHxy4CsaXWaZr9Z01viVfml1xCblUnr76GsMjlEsi/Q7SFupw==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.7.1.tgz",
+      "integrity": "sha512-fjut+07G4Avp6Lly/6hQePpUpQFv9ZyQd+7JC5iCDKg+dWa2Sw7fXD3pBrkzslYFfKqGx9M6kyIaLpg9VeMsjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jest-junit": "^16.0.0",
     "knip": "^5.64.1",
     "prettier": "^3.6.2",
-    "testcontainers": "^11.7.0",
+    "testcontainers": "^11.7.1",
     "ts-jest": "^29.4.4",
     "typescript": "^5.9.3"
   },
@@ -69,6 +69,6 @@
   },
   "overrides": {
     "tmp": "^0.2.4",
-    "tar-fs": "3.1.0"
+    "tar-fs": "3.1.1"
   }
 }


### PR DESCRIPTION
## Description
Updated npm dependencies and overrides to resolve security vulnerabilities:
- `testcontainers` bumped from 11.7.0 to 11.7.1
- `tar-fs` override updated from 3.1.0 to 3.1.1 to remediate CVE-2025-59343 (symlink validation bypass)

This ensures our lockfile pulls in patched versions and clears active Dependabot alerts.

## Related Issue
Fixes Dependabot alert #6 for CVE-2025-59343 in `tar-fs`.

## Motivation and Context
`tar-fs` versions >= 3.0.0 and < 3.1.1 are vulnerable to a symlink validation bypass that could allow malicious tarballs to write files outside the intended extraction directory if the destination is predictable.

Since `testcontainers` 11.7.0 transitively depends on the vulnerable `tar-fs` 3.1.0, upgrading to `testcontainers` 11.7.1 (which uses `tar-fs` 3.1.1) resolves the vulnerability. The override ensures the patched version is enforced across the dependency tree.

## How Has This Been Tested?
- Ran `npm install` after updates to confirm patched versions resolved in `npm ls tar-fs` and `npm ls testcontainers`
- Verified that `tar-fs` 3.1.1 appears in dependency tree with no vulnerable versions
- Confirmed no regressions in local test suite (`npm test`)
- Validated that Dependabot alert criteria are met

## Documentation:
No documentation updates required since this is a dependency security update.

## Checklist:
- [x] I have updated the documentation accordingly. (N/A – no docs required)
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have requested a review from at least 2 reviewers.
- [x] I have checked the base branch of this pull request.
- [x] I have checked my code for any possible security vulnerabilities.