### PR TITLE
fix(runtime): handle error respons correctly

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -42,6 +42,7 @@ export class BaseAPI {
     if (response && response.status >= 200 && response.status < 300) {
       return response;
     }
+    const responseData = await response.json();
     throw new ApiException(
       'Response returned an error code',
       response.status,
@@ -51,7 +52,7 @@ export class BaseAPI {
           Array.isArray(v) ? v : [v],
         ]),
       ),
-      response?.body?.toString(),
+      responseData as string | Record<string, unknown> | null | undefined,
     );
   }
 
@@ -191,13 +192,13 @@ type HTTPMethod =
 export type HTTPHeaders = { [key: string]: string };
 type HTTPQuery = {
   [key: string]:
-    | string
-    | number
-    | null
-    | boolean
-    | Array<string | number | null | boolean>
-    | Set<string | number | null | boolean>
-    | HTTPQuery;
+  | string
+  | number
+  | null
+  | boolean
+  | Array<string | number | null | boolean>
+  | Set<string | number | null | boolean>
+  | HTTPQuery;
 };
 type HTTPBody = Json | FormData | URLSearchParams;
 type HTTPRequestInit = {
@@ -284,7 +285,7 @@ export class JSONApiResponse<T> {
   constructor(
     public raw: Response,
     private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue,
-  ) {}
+  ) { }
 
   async value(): Promise<T> {
     return this.transformer(await this.raw.json());


### PR DESCRIPTION
## Description

This PR fixes an issue where the SDK did not return a clear or useful error response when an API request failed.  
Previously, the `request()` method threw an `ApiException` with the raw `Response` object, without parsing its JSON body.  
As a result, applications could not access the actual error message returned by the Zitadel API.

This PR updates the method to parse the error body via `response.json()` and pass the parsed data into `ApiException`, enabling clearer debugging and proper error handling.

---

## Related Issue

_No official GitHub issue existed. This bug was discovered during real-world integration of the Zitadel Node SDK._

---

## Motivation and Context

When the Zitadel API returned an error response (e.g., 400/401/404), the SDK exposed only a generic  
`Response returned an error code` message.  
Critical information—such as error codes, messages, or details returned by the Zitadel backend—was not available to the developer.

This made debugging and error handling difficult.

By parsing and forwarding the JSON error body, developers now receive:

- meaningful error messages  
- proper Zitadel error codes  
- structured error metadata  

This greatly improves the developer experience when using the SDK.
