### PR TITLE
fix: add package exports and build for git installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 COPY package.json package-lock.json* ./
 
-RUN npm ci --no-progress
+# Skip lifecycle scripts during install to avoid triggering the prepare build
+# before sources are copied. Build explicitly after sources are in place.
+RUN npm ci --no-progress --ignore-scripts
 
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "prepack": "tsc",
+    "prepare": "npm run build",
     "build": "tsc",
     "test": "jest --verbose --config=jest.config.mjs --runInBand",
     "test:watch": "npm run test -- --watch",
@@ -23,6 +24,19 @@
   "files": [
     "dist"
   ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    },
+    "./package.json": "./package.json"
+  },
   "license": "Apache-2.0",
   "description": "TODO",
   "private": false,


### PR DESCRIPTION
## Description

Added main, types, and exports pointing to dist/index so consumers can import from the package root. Added a prepare script so dist is built during git installs.

## Related Issue

None

## Motivation and Context

GitHub installs were missing dist, causing `ERR_MODULE_NOT_FOUND` when importing `@zitadel/zitadel-node/dist/index.js`. Root-level imports also failed because no entrypoint was declared.

## How Has This Been Tested?

Ran npm run build and then inn a fresh temp project using Node 20, we ran.

```
npm init -y
npm_config_cache="$PWD/.npm-cache" 
npm install ../
```

Once linked, we validated that the issue was resolved since we are now able to use proper ESM imports.

```
import Zitadel, { ApiException } from '@zitadel/zitadel-node';
```

## Documentation:

The Readme is up to date.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
