### PR TITLE
Add require to export for CJS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "undici": "^7.24.0"
       },
       "devDependencies": {
-        "@codedependant/semantic-release-docker": "^5.1.1",
         "@commitlint/config-conventional": "^20.0.0",
         "@jest/globals": "^30.2.0",
         "@mridang/eslint-defaults": "^1.6.1",
+        "@mridang/semantic-release-oci": "^1.0.0",
         "@mridang/semantic-release-peer-version": "^1.2.0",
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/exec": "^7.1.0",
@@ -43,54 +43,51 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -631,22 +628,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@codedependant/semantic-release-docker": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@codedependant/semantic-release-docker/-/semantic-release-docker-5.1.1.tgz",
-      "integrity": "sha512-gACzBuAVRBRAJOvGqCXZoMGSpVlyqbAp/LoiJnBc/Fl4B+ZqJyI95uwRNJXSuMQXTUI/I49RTmdetWWU8f/a5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@semantic-release/error": "^3.0.0",
-        "debug": "^4.1.1",
-        "execa": "^4.0.2",
-        "handlebars": "^4.7.7",
-        "object-hash": "^3.0.0",
-        "semver": "^7.3.2"
-      }
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1004,16 +985,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1914,6 +1885,30 @@
       },
       "peerDependencies": {
         "eslint": ">=9"
+      }
+    },
+    "node_modules/@mridang/semantic-release-oci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mridang/semantic-release-oci/-/semantic-release-oci-1.0.0.tgz",
+      "integrity": "sha512-Nytf4ecaG2JW4o9kQJjH3wQ05mVrCm9ZpqJDKMSbKVWzsKIL368+Rx7dLUC+cg92whup3d3jo+M4oVlc7U9fmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@actions/core": "^3.0.0",
+        "@semantic-release/error": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@mridang/semantic-release-oci/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@mridang/semantic-release-peer-version": {
@@ -8130,46 +8125,6 @@
         "bare-events": "^2.7.0"
       }
     },
-    "node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -9066,16 +9021,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.12.0"
       }
     },
     "node_modules/ieee754": {
@@ -14693,6 +14638,7 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   "homepage": "https://github.com/zitadel/zitadel-node",
   "bugs": "https://github.com/zitadel/zitadel-node/issues",
   "devDependencies": {
-    "@codedependant/semantic-release-docker": "^5.1.1",
     "@commitlint/config-conventional": "^20.0.0",
     "@jest/globals": "^30.2.0",
     "@mridang/eslint-defaults": "^1.6.1",
+    "@mridang/semantic-release-oci": "^1.0.0",
     "@mridang/semantic-release-peer-version": "^1.2.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./dist/*": {
       "types": "./dist/*.d.ts",
-      "import": "./dist/*.js"
+      "import": "./dist/*.js",
+      "require": "./dist/*.js"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "description": "TODO",
   "private": false,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -42,7 +42,7 @@ export default {
       },
     ],
     [
-      '@codedependant/semantic-release-docker',
+      '@mridang/semantic-release-oci',
       {
         dockerRegistry: 'ghcr.io',
         dockerProject: 'zitadel',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hey, I have just tried this new sdk in my nestjs project. I found this minor issue and solved it with a simple patch. I think it might be useful to others too. 

## Description
<!--- Describe your changes -->

Added explicit `require` conditions to the `exports` map pointing to the same `dist` files, allowing Node.js to resolve the package correctly in CJS contexts while still loading the same native ES module underneath.

This is a non-breaking change — the files themselves are unchanged, only the export conditions are extended.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When using @zitadel/sdk in a CommonJS project, attempting to require the package fails with:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in node_modules/@zitadel/sdk/package.json
```
This happens because the exports map only defines import conditions, so Node.js has no entry point to use when the package is loaded via require(). This affects any project where the root package.json does not have "type": "module", since in that context Node.js will attempt to load dependencies via require().
Node.js 22.12+ supports require(esm) natively by default — it can load ES modules transparently via require() without any flags. However, it can only do so if the exports map explicitly exposes a require condition to resolve to.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I basically patched the SDK package.json in my node_modules. You can run a quick test before and after adding these changes:
```
node -e "require('@zitadel/sdk')"
```
will fail if the `require` is not declared in the package.json.

## Documentation:

<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->
- [Node.js 22.12.0 release notes — `require(esm)` enabled by default](https://nodejs.org/en/blog/release/v22.12.0)

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
